### PR TITLE
Fix typo in documentation

### DIFF
--- a/app/views/static/documentation.html.md
+++ b/app/views/static/documentation.html.md
@@ -100,7 +100,7 @@ ruby! {
 >> require 'console'
 >> Console.log("Hi from Rust!");
 "LOG: Hi from Rust"
->> Console.new.log("Hi from Rust. Stern warning")
+>> Console.new.warn("Hi from Rust. Stern warning")
 "WARN: Hi from Rust. Stern warning"
 ```
 


### PR DESCRIPTION
This method defined in the example isn't the one the example calls.

In fact, as far as I can tell, Rust won't actually let you define a class and instance method with the same name at all (short of some trait  trickery I don't entirely understand).