### PR TITLE
"thee" next to a quote should be counted

### DIFF
--- a/crates/word_count/spec/fixtures/thee-by-quotes.csv
+++ b/crates/word_count/spec/fixtures/thee-by-quotes.csv
@@ -1,0 +1,2 @@
+IV,III,GRUMIO,"thee, I bid thy master cut out the gown; but I did"
+II,V,MALVOLIO,"thee, Malvolio?"

--- a/crates/word_count/spec/word_count_spec.rb
+++ b/crates/word_count/spec/word_count_spec.rb
@@ -6,4 +6,10 @@ describe "WordCount" do
     expect(WordCount.search(path, "thee")).to eq(3034)
     expect(WordCount.ruby_search(path, "thee")).to eq(3034)
   end
+
+  it "can count words next to quotes" do
+    path = File.expand_path("fixtures/thee-by-quotes.csv", File.dirname(__FILE__))
+    expect(WordCount.search(path, "thee")).to eq(2)
+    expect(WordCount.ruby_search(path, "thee")).to eq(2)
+  end
 end


### PR DESCRIPTION
Hi,

I'm trying to improve the performance of the Ruby implementation of the word search, but I can't really understand the search requirements from the specs.  This PR contains a test which I believe to be a bug.  The existing Ruby code will return 0, but the CSV file contains two instances of the search string.  Is 0 expected?

As a side note, I wasn't able to get the Rust implementation working so I don't know what it returns.  When I try to build the Rust side, I get a bunch of errors like this:

```
error: expected identifier, found keyword `struct`
  --> /Users/aaron/.cargo/registry/src/github.com-1ecc6299db9ec823/helix-0.5.0/src/macros/mod.rs:41:22
   |
41 |         struct: { $($struct:tt)+ },
   |                      ^^^^^^
```

Thanks!