### PR TITLE
Does search support punctuation?

### DIFF
--- a/crates/word_count/spec/fixtures/thee-by-quotes.csv
+++ b/crates/word_count/spec/fixtures/thee-by-quotes.csv
@@ -1,0 +1,2 @@
+IV,III,GRUMIO,"thee, I bid thy master cut out the gown; but I did"
+II,V,MALVOLIO,"thee, Malvolio?"

--- a/crates/word_count/spec/word_count_spec.rb
+++ b/crates/word_count/spec/word_count_spec.rb
@@ -6,4 +6,16 @@ describe "WordCount" do
     expect(WordCount.search(path, "thee")).to eq(3034)
     expect(WordCount.ruby_search(path, "thee")).to eq(3034)
   end
+
+  it "can count strings with punctuation" do
+    path = File.expand_path("fixtures/thee-by-quotes.csv", File.dirname(__FILE__))
+
+    # Without punctuation
+    expect(WordCount.search(path, "malvolio")).to eq(1)
+    expect(WordCount.ruby_search(path, "malvolio")).to eq(1)
+
+    # With punctuation
+    expect(WordCount.search(path, ",malvolio")).to eq(1)
+    expect(WordCount.ruby_search(path, ",malvolio")).to eq(1)
+  end
 end


### PR DESCRIPTION
Does this search implementation support punctuation?  I mean, is it a true "substring" search, or does it only count words?  I've added a test to illustrate the question.  In the test, I search for `malvolio` and it returns 1, but if I search for `,malvolio`, it returns 0 even though the CSV contains that substring.  If the search string is only allowed to have word characters, I think it should raise an exception.

Thanks.