### PR TITLE
Are uppercase strings supported?

### DIFF
--- a/crates/word_count/spec/fixtures/thee-by-quotes.csv
+++ b/crates/word_count/spec/fixtures/thee-by-quotes.csv
@@ -1,0 +1,2 @@
+IV,III,GRUMIO,"thee, I bid thy master cut out the gown; but I did"
+II,V,MALVOLIO,"thee, Malvolio?"

--- a/crates/word_count/spec/word_count_spec.rb
+++ b/crates/word_count/spec/word_count_spec.rb
@@ -6,4 +6,11 @@ describe "WordCount" do
     expect(WordCount.search(path, "thee")).to eq(3034)
     expect(WordCount.ruby_search(path, "thee")).to eq(3034)
   end
+
+  it "can count uppercase strings" do
+    path = File.expand_path("fixtures/thee-by-quotes.csv", File.dirname(__FILE__))
+
+    expect(WordCount.search(path, "MALVOLIO")).to eq(1)
+    expect(WordCount.ruby_search(path, "MALVOLIO")).to eq(1)
+  end
 end


### PR DESCRIPTION
This test case returns 0 matches, but `MALVOLIO` is a substring of the CSV.  If search is supposed to be case insensitive, we should probably downcase the search string as well as the haystack string.

Thanks!