### PR TITLE
Add a note diverging library versions

### DIFF
--- a/app/views/static/getting_started.html.md
+++ b/app/views/static/getting_started.html.md
@@ -62,7 +62,7 @@ pressing **Ctrl+C**.
 
 # Step 2: Generate a Helix crate
 
-To start using Helix, add the `helix-rails` gem to your Gemfile:
+To start using Helix, add the `helix-rails` gem to your Gemfile. (Note: The version of `helix-rails` does not necessarily match the version of the `helix_runtime` gem or the `helix` crate)
 
 ```{Gemfile}ruby
 source 'https://rubygems.org'


### PR DESCRIPTION
I stumbled over this and and assumed the tutorial was outdated and I had to install helix-rails 0.7.3 for helix 0.7.3. This led to more confusion, especially since there is a helix_runtime gem in version 0.7.3.