### PR TITLE
Fix: Display correct source code for line_point demo

### DIFF
--- a/app/views/demos/line_point/show.html.erb
+++ b/app/views/demos/line_point/show.html.erb
@@ -34,10 +34,10 @@
 
   <ul>
     <li>
-      <%= github_link "Crate", "crates/inline_css/" %>:
-      <%= github_link "Class", "crates/inline_css/src/lib.rs" %>
+      <%= github_link "Crate", "crates/line_point/" %>:
+      <%= github_link "Class", "crates/line_point/src/lib.rs" %>
     </li>
-    <li><%= github_link "Controller", "app/controllers/demos/inline_css_controller.rb" %></li>
-    <li><%= github_link "View", "app/views/demos/inline_css/show.html.erb" %></li>
+    <li><%= github_link "Controller", "app/controllers/demos/line_point_controller.rb" %></li>
+    <li><%= github_link "View", "app/views/demos/line_point/show.html.erb" %></li>
   </ul>
 </p>


### PR DESCRIPTION
I was just browsing through and noticed that the source links for the `Line and Point` demo were actually redirecting me to a different demo - the `Inline CSS` one.