### PR TITLE
use ruby 2.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.7.2'
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"


### PR DESCRIPTION
Upgrade to Ruby `2.7.2` so we can upgrade from heroku-16 stack to heroku-20. heroku-16 will be EOL'ng soon.